### PR TITLE
category form UI: auto-completion

### DIFF
--- a/static_src/app.js
+++ b/static_src/app.js
@@ -80,5 +80,10 @@ module.exports = function(template) {
         return el ? el.value : null;
     };
 
+    self.setValue = function(name, value) {
+        var el = element.querySelector('[name="' + name + '"]');
+        el.value = value;
+    };
+
     return self;
 };

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -206,6 +206,7 @@ var onMapInit = function(event) {
 };
 
 var onCategoryAdd = function(event, state, app) {
+    event.preventDefault();
     state.formCategories.push([app.getValue('category'), app.getValue('subcategory')]);
     app.setValue('category', '');
     app.setValue('subcategory', '');
@@ -225,7 +226,7 @@ var app = createApp(template);
 app.bindEvent('.filter', 'change', onFilter);
 app.bindEvent('.filter', 'search', onFilter);
 app.bindEvent('.filter', 'keyup', onFilter);
-app.bindEvent('form', 'submit', onSubmit);
+app.bindEvent('#form', 'submit', onSubmit);
 app.bindEvent('.delete', 'click', onDelete);
 app.bindEvent('textarea', 'init', resize);
 app.bindEvent('textarea', 'input', resize);
@@ -233,7 +234,7 @@ app.bindEvent('.category-filters .js-all', 'click', onFilterAll);
 app.bindEvent('.category-filters .js-none', 'click', onFilterAll);
 app.bindEvent('.category-filters input[type=checkbox]', 'change', onFilterChange);
 app.bindEvent('.map', 'init', onMapInit);
-app.bindEvent('.category-add', 'click', onCategoryAdd);
+app.bindEvent('#category-add-form', 'submit', onCategoryAdd);
 app.bindEvent('.category-remove', 'click', onCategoryRemove);
 app.bindEvent(window, 'popstate', onNavigate);
 

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -220,6 +220,14 @@ var onCategoryRemove = function(event, state, app) {
     return state;
 };
 
+var onCategoryChange = function(event, state, app) {
+    var category = app.getValue('category');
+    var el = document.querySelector('#list-subcategories');
+    Array.prototype.forEach.call(el.children, option => {
+        option.disabled = category && category !== option.dataset.category;
+    });
+};
+
 // main
 var app = createApp(template);
 
@@ -236,6 +244,7 @@ app.bindEvent('.category-filters input[type=checkbox]', 'change', onFilterChange
 app.bindEvent('.map', 'init', onMapInit);
 app.bindEvent('#category-add-form', 'submit', onCategoryAdd);
 app.bindEvent('.category-remove', 'click', onCategoryRemove);
+app.bindEvent('[name="category"]', 'change', onCategoryChange);
 app.bindEvent(window, 'popstate', onNavigate);
 
 updateModel().then(function(model) {

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -20,10 +20,6 @@ var updateModel = function() {
         };
 
         entries.forEach(function(entry) {
-            // FIXME: temporary compat code
-            entry.category = entry.categories[0][0];
-            entry.subcategory = entry.categories[0][1];
-
             entry.categories.forEach(function(c) {
                 var category = _.findByKey(model.categories, c[0]);
                 if (!category) {

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -209,12 +209,19 @@ var onMapInit = function(event) {
     }
 };
 
-var onCategoryChange = function(event, state, app) {
-    var parts = app.getValue('category').split('--');
-    state.subcategory = parts[1];
+var onCategoryAdd = function(event, state, app) {
+    state.formCategories.push([app.getValue('category'), app.getValue('subcategory')]);
+    app.setValue('category', '');
+    app.setValue('subcategory', '');
     return state;
 };
 
+var onCategoryRemove = function(event, state, app) {
+    var el = event.target.closest('li');
+    var i = Array.prototype.indexOf.call(el.parentElement.children, el);
+    state.formCategories.splice(i, 1);
+    return state;
+};
 
 // main
 var app = createApp(template);
@@ -230,8 +237,8 @@ app.bindEvent('.category-filters .js-all', 'click', onFilterAll);
 app.bindEvent('.category-filters .js-none', 'click', onFilterAll);
 app.bindEvent('.category-filters input[type=checkbox]', 'change', onFilterChange);
 app.bindEvent('.map', 'init', onMapInit);
-app.bindEvent('[name=category]', 'change', onCategoryChange);
-app.bindEvent('[name=category]', 'init', onCategoryChange);
+app.bindEvent('.category-add', 'click', onCategoryAdd);
+app.bindEvent('.category-remove', 'click', onCategoryRemove);
 app.bindEvent(window, 'popstate', onNavigate);
 
 updateModel().then(function(model) {

--- a/static_src/scss/form.scss
+++ b/static_src/scss/form.scss
@@ -46,3 +46,14 @@ button,
     line-height: inherit;
     padding: 0 0.2em;
 }
+
+.category-row {
+    display: grid;
+    grid-template-columns: 2fr 2fr 1fr;
+    grid-gap: $padding;
+    align-items: end;
+}
+.category-row button {
+    font-size: 100%;
+    line-height: 1.8;
+}

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -236,7 +236,7 @@ var form = function(state, entry) {
         h('datalist', {id: 'list-subcategories'}, state.categories.map(function(category) {
             var options = [];
             category.children.forEach(function(subcategory) {
-                options.push(h('option', {}, subcategory.key));
+                options.push(h('option', {'data-category': category.key}, subcategory.key));
             });
             return options;
         })),

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -226,8 +226,8 @@ var field = function(name, value, params, type) {
 var form = function(state, entry) {
     var categoryFields = [
         h('div', {'class': 'category-row'}, [
-            field('category', '', {list: 'list-categories', form: 'category-add-form'}),
-            field('subcategory', '', {list: 'list-subcategories', form: 'category-add-form'}),
+            field('category', '', {list: 'list-categories', autocomplete: 'off', form: 'category-add-form'}),
+            field('subcategory', '', {list: 'list-subcategories', autocomplete: 'off', form: 'category-add-form'}),
             h('button', {form: 'category-add-form'}, 'Hinzufügen'),
         ]),
         h('datalist', {id: 'list-categories'}, state.categories.map(function(category) {

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -70,12 +70,14 @@ var error = function(msg) {
     return h('h2', {'class': 'error'}, 'Fehler: ' + msg);
 };
 
-var categoryList = function(state, entry) {
-    return h('ul', {'class': 'category-list'}, entry.categories.map(function(c) {
+var categoryList = function(state, categories, button) {
+    return h('ul', {'class': 'category-list'}, categories.map(function(c) {
         return h('li', {}, [
             h('span', {'class': 'category ' + categoryClass(state, c)}, c[0]),
             ' ',
             h('span', {'class': 'subcategory'}, c[1]),
+            ' ',
+            button && h('button', {'class': 'category-remove button--secondary button--small', type: 'button'}, 'Löschen'),
         ]);
     }));
 };
@@ -85,7 +87,7 @@ var listItem = function(state, entry) {
         href: '#!detail/' + entry.id,
         'class': 'list-item',
     }, [
-        categoryList(state, entry),
+        categoryList(state, entry.categories),
         h('h2', {'class': 'list-item__title'}, entry.name),
         h('span', {'class': 'lang'}, entry.lang),
     ]);
@@ -157,7 +159,7 @@ var detail = function(state, entry) {
 
     var children = [
         h('header', {'class': 'detail__header'}, [
-            categoryList(state, entry),
+            categoryList(state, entry.categories),
             h('h2', {}, entry.name),
             h('span', {'class': 'lang'}, entry.lang),
             clientToggle,
@@ -223,31 +225,23 @@ var field = function(name, value, params, type) {
 
 var form = function(state, entry) {
     var categoryFields = [
-        h('label', {}, [
-            LABELS.category + '/' + LABELS.subcategory,
-            h('select', {
-                name: 'category',
-                required: true,
-            }, [h('option')].concat(state.categories.map(function(category) {
-                return h('optgroup', {
-                    label: category.key,
-                }, category.children.map(function(subcategory) {
-                    return h('option', {
-                        value: category.key + '--' + subcategory.key,
-                        selected: entry.subcategory === subcategory.key,
-                    }, subcategory.key);
-                }).concat([
-                    h('option', {
-                        value: category.key + '--',
-                    }, 'neu ...'),
-                ]));
-            }))),
+        h('div', {'class': 'category-row'}, [
+            field('category', '', {list: 'list-categories'}),
+            field('subcategory', '', {list: 'list-subcategories'}),
+            h('button', {'class': 'category-add', type: 'button'}, 'Hinzufügen'),
         ]),
+        h('datalist', {id: 'list-categories'}, state.categories.map(function(category) {
+            return h('option', {}, category.key);
+        })),
+        h('datalist', {id: 'list-subcategories'}, state.categories.map(function(category) {
+            var options = [];
+            category.children.forEach(function(subcategory) {
+                options.push(h('option', {}, subcategory.key));
+            });
+            return options;
+        })),
+        categoryList(state, state.formCategories, true),
     ];
-
-    if (state.subcategory === '') {
-        categoryFields.push(field('subcategory', '', {required: true}));
-    }
 
     return h('form', {}, [
         field('name', entry.name, {required: true}),

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -226,9 +226,9 @@ var field = function(name, value, params, type) {
 var form = function(state, entry) {
     var categoryFields = [
         h('div', {'class': 'category-row'}, [
-            field('category', '', {list: 'list-categories'}),
-            field('subcategory', '', {list: 'list-subcategories'}),
-            h('button', {'class': 'category-add', type: 'button'}, 'Hinzufügen'),
+            field('category', '', {list: 'list-categories', form: 'category-add-form'}),
+            field('subcategory', '', {list: 'list-subcategories', form: 'category-add-form'}),
+            h('button', {form: 'category-add-form'}, 'Hinzufügen'),
         ]),
         h('datalist', {id: 'list-categories'}, state.categories.map(function(category) {
             return h('option', {}, category.key);
@@ -243,7 +243,7 @@ var form = function(state, entry) {
         categoryList(state, state.formCategories, true),
     ];
 
-    return h('form', {}, [
+    var form = h('form', {id: 'form'}, [
         field('name', entry.name, {required: true}),
         h('fieldset', {}, categoryFields),
         field('address', entry.address, {required: true}, 'textarea'),
@@ -261,6 +261,11 @@ var form = function(state, entry) {
                 href: entry.id ? '#!detail/' + entry.id : '#!list',
             }, 'Abbrechen'),
         ]),
+    ]);
+
+    return h('div', {}, [
+        form,
+        h('form', {id: 'category-add-form'}),
     ]);
 };
 


### PR DESCRIPTION
based on #2 

![2021-10-22_18-47-17](https://user-images.githubusercontent.com/202576/138492917-d293055e-5702-478e-9b92-2cab99e49a90.png)

- Previously you had to select a subcategory from a dropdown. Optionally you could select the option "new" and then enter a new subcategory in a second input field. I combined this into a single text field with autocompletion
  - pros
    - I tested browser support in firefox and chrome on desktop and it worked fine
    - if users ignore the autocompletion (or it is not supported by their browsers) they may create many redundant (sub)categories
    - as a byproduct, users can now create new categories, not only subcategories.
  - cons
    - category and subcategory have to be entered in separate fields.
    - this is not a super common UI pattern, not sure how easy it is to use
- I wanted to make the two fields required, but then firefox highlighted them in red before I even stared to interact with the form. Not sure why. However, I believe that the result of adding an empty category is just as good a feedback as a "this field is required" warning.
- I did not find a simple way to give users feedback that there should be at least one category. However, I don't think that requirement is totally necessary, so I ignored it.
- When you enter something in the category/subcategory fields and the press enter, a new category is added. I achieved that by assigning those fields to a separate form (forms cannot be nested in HTML, so I had to use the [`form` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-form). This is not very common and probably confusing for many developers.
- I am not sure what to do if the category/subcategory fields are not empty when the form is submitted. The current behavior is to ignore that. We could also think about warning the user in that case.