### PR TITLE
category form UI: add button

### DIFF
--- a/static_src/app.js
+++ b/static_src/app.js
@@ -80,5 +80,10 @@ module.exports = function(template) {
         return el ? el.value : null;
     };
 
+    self.setValue = function(name, value) {
+        var el = element.querySelector('[name="' + name + '"]');
+        el.value = value;
+    };
+
     return self;
 };

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -137,7 +137,7 @@ var onSubmit = function(event, state, app) {
     }
 
     // prevent double-submit
-    var submit = event.target.querySelector('button');
+    var submit = event.target.querySelector('nav button');
     submit.disabled = true;
 
     var data = {
@@ -211,8 +211,22 @@ var onMapInit = function(event) {
 };
 
 var onCategoryChange = function(event, state, app) {
-    var parts = app.getValue('category').split('--');
-    state.subcategory = parts[1];
+    var parts = app.getValue('category-select').split('--');
+    app.setValue('category', parts[0]);
+    app.setValue('subcategory', parts[1] || '');
+    state.categoryTextFieldsShown = parts[1] === '';
+    return state;
+};
+
+var onCategoryAdd = function(event, state, app) {
+    state.formCategories.push([
+        app.getValue('category'),
+        app.getValue('subcategory'),
+    ]);
+    state.categoryTextFieldsShown = false;
+    app.setValue('category-select', '');
+    app.setValue('category', '');
+    app.setValue('subcategory', '');
     return state;
 };
 
@@ -237,8 +251,9 @@ app.bindEvent('.category-filters .js-all', 'click', onFilterAll);
 app.bindEvent('.category-filters .js-none', 'click', onFilterAll);
 app.bindEvent('.category-filters input[type=checkbox]', 'change', onFilterChange);
 app.bindEvent('.map', 'init', onMapInit);
-app.bindEvent('[name=category]', 'change', onCategoryChange);
-app.bindEvent('[name=category]', 'init', onCategoryChange);
+app.bindEvent('[name="category-select"]', 'change', onCategoryChange);
+app.bindEvent('[name="category-select"]', 'init', onCategoryChange);
+app.bindEvent('.category-add', 'click', onCategoryAdd);
 app.bindEvent('.category-remove', 'click', onCategoryRemove);
 app.bindEvent(window, 'popstate', onNavigate);
 

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -140,8 +140,9 @@ var onSubmit = function(event, state, app) {
     var submit = event.target.querySelector('nav button');
     submit.disabled = true;
 
+    var collator = new Intl.Collator('de');
     var data = {
-        categories: state.formCategories,
+        categories: state.formCategories.slice().sort(collator.compare),
     };
 
     // HACK: These inputs are not synced with the vdom.

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -131,6 +131,11 @@ var onNavigate = function(event, state) {
 var onSubmit = function(event, state, app) {
     event.preventDefault();
 
+    if (state.formCategories.length === 0) {
+        alert('Bitte füge eine Rubrik hinzu!');
+        return;
+    }
+
     // prevent double-submit
     var submit = event.target.querySelector('button');
     submit.disabled = true;

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -219,14 +219,13 @@ var onCategoryChange = function(event, state, app) {
 };
 
 var onCategoryAdd = function(event, state, app) {
+    event.preventDefault();
     state.formCategories.push([
         app.getValue('category'),
         app.getValue('subcategory'),
     ]);
     state.categoryTextFieldsShown = false;
-    app.setValue('category-select', '');
-    app.setValue('category', '');
-    app.setValue('subcategory', '');
+    event.target.reset();
     return state;
 };
 
@@ -243,7 +242,7 @@ var app = createApp(template);
 app.bindEvent('.filter', 'change', onFilter);
 app.bindEvent('.filter', 'search', onFilter);
 app.bindEvent('.filter', 'keyup', onFilter);
-app.bindEvent('form', 'submit', onSubmit);
+app.bindEvent('#form', 'submit', onSubmit);
 app.bindEvent('.delete', 'click', onDelete);
 app.bindEvent('textarea', 'init', resize);
 app.bindEvent('textarea', 'input', resize);
@@ -253,7 +252,7 @@ app.bindEvent('.category-filters input[type=checkbox]', 'change', onFilterChange
 app.bindEvent('.map', 'init', onMapInit);
 app.bindEvent('[name="category-select"]', 'change', onCategoryChange);
 app.bindEvent('[name="category-select"]', 'init', onCategoryChange);
-app.bindEvent('.category-add', 'click', onCategoryAdd);
+app.bindEvent('#category-add-form', 'submit', onCategoryAdd);
 app.bindEvent('.category-remove', 'click', onCategoryRemove);
 app.bindEvent(window, 'popstate', onNavigate);
 

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -20,10 +20,6 @@ var updateModel = function() {
         };
 
         entries.forEach(function(entry) {
-            // FIXME: temporary compat code
-            entry.category = entry.categories[0][0];
-            entry.subcategory = entry.categories[0][1];
-
             entry.categories.forEach(function(c) {
                 var category = _.findByKey(model.categories, c[0]);
                 if (!category) {

--- a/static_src/main.js
+++ b/static_src/main.js
@@ -215,6 +215,12 @@ var onCategoryChange = function(event, state, app) {
     return state;
 };
 
+var onCategoryRemove = function(event, state, app) {
+    var el = event.target.closest('li');
+    var i = Array.prototype.indexOf.call(el.parentElement.children, el);
+    state.formCategories.splice(i, 1);
+    return state;
+};
 
 // main
 var app = createApp(template);
@@ -232,6 +238,7 @@ app.bindEvent('.category-filters input[type=checkbox]', 'change', onFilterChange
 app.bindEvent('.map', 'init', onMapInit);
 app.bindEvent('[name=category]', 'change', onCategoryChange);
 app.bindEvent('[name=category]', 'init', onCategoryChange);
+app.bindEvent('.category-remove', 'click', onCategoryRemove);
 app.bindEvent(window, 'popstate', onNavigate);
 
 updateModel().then(function(model) {

--- a/static_src/scss/form.scss
+++ b/static_src/scss/form.scss
@@ -44,3 +44,17 @@ button {
     line-height: inherit;
     padding: 0 0.2em;
 }
+
+.category-row {
+    display: flex;
+    gap: $padding;
+    align-items: flex-end;
+}
+.category-row label {
+    flex-grow: 1;
+}
+.category-row button {
+    width: auto;
+    font-size: 100%;
+    line-height: 1.8;
+}

--- a/static_src/scss/form.scss
+++ b/static_src/scss/form.scss
@@ -20,6 +20,10 @@ input[type="checkbox"] {
     width: auto;
 }
 
+select {
+    height: calc(2.4em + 2px);
+}
+
 .button,
 button {
     display: block;

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -70,8 +70,8 @@ var error = function(msg) {
     return h('h2', {'class': 'error'}, 'Fehler: ' + msg);
 };
 
-var categoryList = function(state, entry) {
-    return h('ul', {'class': 'category-list'}, entry.categories.map(function(c) {
+var categoryList = function(state, categories) {
+    return h('ul', {'class': 'category-list'}, categories.map(function(c) {
         return h('li', {}, [
             h('span', {'class': 'category ' + categoryClass(state, c)}, c[0]),
             ' ',
@@ -85,7 +85,7 @@ var listItem = function(state, entry) {
         href: '#!detail/' + entry.id,
         'class': 'list-item',
     }, [
-        categoryList(state, entry),
+        categoryList(state, entry.categories),
         h('h2', {'class': 'list-item__title'}, entry.name),
         h('span', {'class': 'lang'}, entry.lang),
     ]);
@@ -157,7 +157,7 @@ var detail = function(state, entry) {
 
     var children = [
         h('header', {'class': 'detail__header'}, [
-            categoryList(state, entry),
+            categoryList(state, entry.categories),
             h('h2', {}, entry.name),
             h('span', {'class': 'lang'}, entry.lang),
             clientToggle,
@@ -243,6 +243,7 @@ var form = function(state, entry) {
                 ]));
             }))),
         ]),
+        categoryList(state, state.formCategories),
     ];
 
     if (state.subcategory === '') {

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -236,7 +236,7 @@ var form = function(state, entry) {
                 }, category.children.map(function(subcategory) {
                     return h('option', {
                         value: category.key + '--' + subcategory.key,
-                        selected: entry.subcategory === subcategory.key,
+                        selected: entry.categories[0][1] === subcategory.key,
                     }, subcategory.key);
                 }).concat([
                     h('option', {

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -223,14 +223,13 @@ var field = function(name, value, params, type) {
     return h('label', {}, [LABELS[name], f]);
 };
 
-var categoryOptions = function(state, entry) {
+var categoryOptions = function(state) {
     return [h('option')].concat(state.categories.map(function(category) {
         return h('optgroup', {
             label: category.key,
         }, category.children.map(function(subcategory) {
             return h('option', {
                 value: category.key + '--' + subcategory.key,
-                selected: entry.categories[0][1] === subcategory.key,
             }, subcategory.key);
         }).concat([
             h('option', {
@@ -242,16 +241,19 @@ var categoryOptions = function(state, entry) {
 
 var form = function(state, entry) {
     var categoryFields = [
-        h('label', {}, [
-            LABELS.category + '/' + LABELS.subcategory,
-            h('select', {name: 'category', required: true}, categoryOptions(state, entry)),
+        h('div', {'class': 'category-row'}, [
+            h('label', {}, [
+                LABELS.category + '/' + LABELS.subcategory,
+                h('select', {name: 'category-select'}, categoryOptions(state)),
+            ]),
+            h('button', {'class': 'category-add', type: 'button'}, 'Hinzufügen'),
+        ]),
+        h('div', {'class': 'category-row', hidden: !state.categoryTextFieldsShown}, [
+            field('category', '', {}),
+            field('subcategory', '', {}),
         ]),
         categoryList(state, state.formCategories, true),
     ];
-
-    if (state.subcategory === '') {
-        categoryFields.push(field('subcategory', '', {required: true}));
-    }
 
     return h('form', {}, [
         field('name', entry.name, {required: true}),

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -70,12 +70,14 @@ var error = function(msg) {
     return h('h2', {'class': 'error'}, 'Fehler: ' + msg);
 };
 
-var categoryList = function(state, categories) {
+var categoryList = function(state, categories, button) {
     return h('ul', {'class': 'category-list'}, categories.map(function(c) {
         return h('li', {}, [
             h('span', {'class': 'category ' + categoryClass(state, c)}, c[0]),
             ' ',
             h('span', {'class': 'subcategory'}, c[1]),
+            ' ',
+            button && h('button', {'class': 'category-remove button--secondary button--small', type: 'button'}, 'Löschen'),
         ]);
     }));
 };
@@ -243,7 +245,7 @@ var form = function(state, entry) {
                 ]));
             }))),
         ]),
-        categoryList(state, state.formCategories),
+        categoryList(state, state.formCategories, true),
     ];
 
     if (state.subcategory === '') {

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -223,27 +223,28 @@ var field = function(name, value, params, type) {
     return h('label', {}, [LABELS[name], f]);
 };
 
+var categoryOptions = function(state, entry) {
+    return [h('option')].concat(state.categories.map(function(category) {
+        return h('optgroup', {
+            label: category.key,
+        }, category.children.map(function(subcategory) {
+            return h('option', {
+                value: category.key + '--' + subcategory.key,
+                selected: entry.categories[0][1] === subcategory.key,
+            }, subcategory.key);
+        }).concat([
+            h('option', {
+                value: category.key + '--',
+            }, 'neu ...'),
+        ]));
+    }));
+};
+
 var form = function(state, entry) {
     var categoryFields = [
         h('label', {}, [
             LABELS.category + '/' + LABELS.subcategory,
-            h('select', {
-                name: 'category',
-                required: true,
-            }, [h('option')].concat(state.categories.map(function(category) {
-                return h('optgroup', {
-                    label: category.key,
-                }, category.children.map(function(subcategory) {
-                    return h('option', {
-                        value: category.key + '--' + subcategory.key,
-                        selected: entry.categories[0][1] === subcategory.key,
-                    }, subcategory.key);
-                }).concat([
-                    h('option', {
-                        value: category.key + '--',
-                    }, 'neu ...'),
-                ]));
-            }))),
+            h('select', {name: 'category', required: true}, categoryOptions(state, entry)),
         ]),
         categoryList(state, state.formCategories, true),
     ];

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -244,18 +244,18 @@ var form = function(state, entry) {
         h('div', {'class': 'category-row'}, [
             h('label', {}, [
                 LABELS.category + '/' + LABELS.subcategory,
-                h('select', {name: 'category-select'}, categoryOptions(state)),
+                h('select', {name: 'category-select', form: 'category-add-form'}, categoryOptions(state)),
             ]),
-            h('button', {'class': 'category-add', type: 'button'}, 'Hinzufügen'),
+            h('button', {'class': 'category-add', form: 'category-add-form'}, 'Hinzufügen'),
         ]),
         h('div', {'class': 'category-row', hidden: !state.categoryTextFieldsShown}, [
-            field('category', '', {}),
-            field('subcategory', '', {}),
+            field('category', '', {required: true, form: 'category-add-form'}),
+            field('subcategory', '', {required: true, form: 'category-add-form'}),
         ]),
         categoryList(state, state.formCategories, true),
     ];
 
-    return h('form', {}, [
+    var form = h('form', {id: 'form'}, [
         field('name', entry.name, {required: true}),
         h('fieldset', {}, categoryFields),
         field('address', entry.address, {required: true}, 'textarea'),
@@ -273,6 +273,11 @@ var form = function(state, entry) {
                 href: entry.id ? '#!detail/' + entry.id : '#!list',
             }, 'Abbrechen'),
         ]),
+    ]);
+
+    return h('div', {}, [
+        form,
+        h('form', {id: 'category-add-form'}),
     ]);
 };
 

--- a/static_src/template.js
+++ b/static_src/template.js
@@ -224,19 +224,23 @@ var field = function(name, value, params, type) {
 };
 
 var categoryOptions = function(state) {
-    return [h('option')].concat(state.categories.map(function(category) {
-        return h('optgroup', {
-            label: category.key,
-        }, category.children.map(function(subcategory) {
-            return h('option', {
-                value: category.key + '--' + subcategory.key,
-            }, subcategory.key);
-        }).concat([
-            h('option', {
-                value: category.key + '--',
-            }, 'neu ...'),
-        ]));
-    }));
+    return [
+        h('option'),
+        state.categories.map(function(category) {
+            return h('optgroup', {
+                label: category.key,
+            }, category.children.map(function(subcategory) {
+                return h('option', {
+                    value: category.key + '--' + subcategory.key,
+                }, subcategory.key);
+            }).concat([
+                h('option', {
+                    value: category.key + '--',
+                }, 'neu ...'),
+            ]));
+        }),
+        h('option', {value: '--'}, 'neu ...'),
+    ];
 };
 
 var form = function(state, entry) {


### PR DESCRIPTION
This is very similar to #4, but I added an "add" button and fixed some of the keyboard related issues I described in https://github.com/kub-berlin/kub-weiterleitungsliste/pull/4#issuecomment-953979714.

I like the idea of encouraging users to re-use existing categories and only show the text fields on explicit request.

To make sure that at least one category is selected I added an error message (see b4f3da8)